### PR TITLE
Fix the basic-optional challenge,  …

### DIFF
--- a/challenges/basic-optional/question.py
+++ b/challenges/basic-optional/question.py
@@ -5,7 +5,7 @@ foo can accept either an integer argument or no argument.
 """
 
 
-def foo(x=0):
+def foo(x):
     pass
 
 


### PR DESCRIPTION
…as the question could pass without having to answer before. 

The question pass itself, for pyright raises error on `foo("10")` for `def foo(x=10)`, which matches the answer. Removing the default value of the argument `x` would fix it. You could verify it [here](https://pyright-play.net/?code=CYUwZgBGD20BQA8CUAuAUBTEAOBDAzvmmjPAIwAMSJscSEAxBCAE4vQsQu4CW%2BIwCAAtWICDwB2%2BAC4hcg6JGkiIEkAmkQANpJA14AIkoGkQA). 