### PR TITLE
feat: adjust details and add hovering transition for playground link overlay

### DIFF
--- a/templates/challenge.html
+++ b/templates/challenge.html
@@ -56,7 +56,7 @@
       margin-bottom: 1rem;
     }
 
-    .challenge-header__title > span:nth-child(1) {
+    .challenge-header__title>span:nth-child(1) {
       font-size: 30px;
       font-weight: bold;
       margin-right: 20px;
@@ -87,12 +87,22 @@
 
     #playground-link {
       position: absolute;
-      top: 0;
-      right: 0;
+      top: 3px;
+      right: 3px;
       padding: 5px;
-      background: #f3f3f3;
+      background: var(--secondary);
+      color: var(--secondary-inverse);
       border-bottom-left-radius: 5px;
-      z-index: 9999;
+      font-size: 12px;
+      text-decoration: none;
+      z-index: 1;
+      opacity: 0;
+      cursor: pointer;
+      transition: all 0.5s ease-in-out;
+    }
+
+    #editor:hover #playground-link {
+      opacity: 1;
     }
 
     .editor-actions {
@@ -172,7 +182,6 @@
     .CodeMirror.CodeMirror-focused {
       border: 2px solid blue;
     }
-
   </style>
 {% endblock %}
 
@@ -209,7 +218,7 @@
         <div class="codemirror-container">
           <div id="editor">
             <a id="playground-link" target="_blank" rel="noopener noreferrer">
-              Open Pyright playground
+              Open Pyright Playground
             </a>
           </div>
           <div class="editor-actions">
@@ -253,7 +262,7 @@
     });
 
     let playgroundLink = document.getElementById("playground-link");
-    playgroundLink.addEventListener('click', function(event) {
+    playgroundLink.addEventListener('click', function (event) {
       const code = myCodeMirror.getValue();
       this.href = "https://pyright-play.net/?code=" + LZString.compressToEncodedURIComponent(code);
     });

--- a/templates/challenge.html
+++ b/templates/challenge.html
@@ -90,6 +90,7 @@
       top: 3px;
       right: 3px;
       padding: 5px;
+      /* The "secondary" style comes from https://picocss.com/docs/buttons.html */
       background: var(--secondary);
       color: var(--secondary-inverse);
       border-bottom-left-radius: 5px;


### PR DESCRIPTION
- Adjust the absolute position of the playground link and refine some UI details
- Show the playground link only when hovering over the editor
