### PR TITLE
use type instead of TypeAlias in recursive solution

### DIFF
--- a/challenges/advanced-recursive/solution.py
+++ b/challenges/advanced-recursive/solution.py
@@ -3,10 +3,10 @@ TODO:
 
 Define a `Tree` type. `Tree` is a dictionary, whose keys are string, values are also `Tree`.
 """
-from typing import Dict, TypeAlias
+from typing import Dict
 
 
-Tree : TypeAlias = Dict[str, 'Tree']
+type Tree = Dict[str, 'Tree']
 
 
 ## End of your code ##

--- a/challenges/advanced-recursive/solution.py
+++ b/challenges/advanced-recursive/solution.py
@@ -3,8 +3,10 @@ TODO:
 
 Define a `Tree` type. `Tree` is a dictionary, whose keys are string, values are also `Tree`.
 """
-from typing import Dict
+from typing import Dict, TypeAlias
 
+# For Python < 3.12
+# Tree : TypeAlias = Dict[str, 'Tree']
 
 type Tree = Dict[str, 'Tree']
 


### PR DESCRIPTION
TypeAlias is deprecated since 3.12 according to https://docs.python.org/3/library/typing.html#typing.TypeAlias

fix #44