### PR TITLE
Enhance: force the user to make some changes before running

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,19 +4,20 @@ inject them into the test functions that need them by signature matching.
 """
 
 
+import random
 from pathlib import Path
 
 import pytest
-from flask.testing import FlaskClient
-
 from app import app
+from flask.testing import FlaskClient
+from views.challenge import Challenge, Level
 
 CHALLENGES_DIR = Path(__file__).parent.parent / "challenges"
 ALL_QUESTIONS = list(CHALLENGES_DIR.glob("**/question.py"))
 ALL_SOLUTIONS = list(CHALLENGES_DIR.glob("**/solution.py"))
 
 
-@pytest.fixture
+@pytest.fixture()
 def test_client() -> FlaskClient:
     return app.test_client()
 
@@ -29,3 +30,11 @@ def question_file(request):
 @pytest.fixture(params=ALL_SOLUTIONS, ids=lambda x: x.parent.name)
 def solution_file(request):
     return request.param
+
+
+@pytest.fixture()
+def random_q_challenge():
+    """Return a random challenge object from the questions poll."""
+    file = random.choice(ALL_QUESTIONS)
+    level, challenge_name = file.parent.name.split("-", maxsplit=1)
+    return Challenge(name=challenge_name, level=Level(level), code=file.read_text())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,8 +8,9 @@ import random
 from pathlib import Path
 
 import pytest
-from app import app
 from flask.testing import FlaskClient
+
+from app import app
 from views.challenge import Challenge, Level
 
 CHALLENGES_DIR = Path(__file__).parent.parent / "challenges"

--- a/tests/test_challenge.py
+++ b/tests/test_challenge.py
@@ -1,6 +1,12 @@
 from views.challenge import ChallengeManager
 
 
+def test_run_not_modified_user_code(random_q_challenge):
+    ret = ChallengeManager().run_challenge(random_q_challenge.key, random_q_challenge.user_code)
+    assert ret.passed is False
+    assert "make some changes" in ret.message
+
+
 def test_run_type_check_with_pyright():
     code = """\
 a: int = 1

--- a/views/challenge.py
+++ b/views/challenge.py
@@ -51,6 +51,10 @@ class Challenge:
     def parse_code(self):
         self.user_code, _, self.test_code = self.code.partition(self.CODE_SPLITTER)
 
+    @property
+    def key(self) -> ChallengeKey:
+        return ChallengeKey(level=self.level, name=self.name)
+
 
 @dataclass(frozen=True, slots=True)
 class TypeCheckResult:
@@ -73,6 +77,8 @@ class ChallengeManager:
 
     def run_challenge(self, key: ChallengeKey, user_code: str) -> TypeCheckResult:
         challenge = self.get_challenge(key)
+        if user_code == challenge.user_code:
+            return TypeCheckResult(message="Please make some changes to the code before running!", passed=False)
         # Make sure user code ends with a new line to avoid issue #63.
         return self._type_check_with_pyright(user_code + "\n", challenge.test_code)
 


### PR DESCRIPTION
In the current version, the user is able to run the code without any modification, which means that when playing the first challenge (`/basic/any`), anyone can pass the challenge without any keystrokes because all variables are already interpreted as `Any` type. 

This is not the ideal experience in my option because no real work is required, which reduces a lot of fun.

This PR forces the user to make some changes to the code before hitting the "run" button.