### PR TITLE
Add hints for most of the basic challenges & improved "basic-optional"

### DIFF
--- a/challenges/basic-dict/hints.md
+++ b/challenges/basic-dict/hints.md
@@ -1,0 +1,1 @@
+Check out [Dict](https://docs.python.org/3/library/typing.html#typing.Dict) or use the built-in `dict` function, the syntax for using `dict` for typing looks like this: `dict[KT, VT]`.

--- a/challenges/basic-final/hints.md
+++ b/challenges/basic-final/hints.md
@@ -1,0 +1,1 @@
+Check out [Final](https://docs.python.org/3/library/typing.html#typing.Final).

--- a/challenges/basic-list/hints.md
+++ b/challenges/basic-list/hints.md
@@ -1,0 +1,1 @@
+Check out [List](https://docs.python.org/3/library/typing.html#typing.List) or use the built-in `list` function, the syntax for using `list` for typing looks like this: `list[T]`.

--- a/challenges/basic-optional/hints.md
+++ b/challenges/basic-optional/hints.md
@@ -1,0 +1,3 @@
+- A union type can be created using the `|` operator, e.g: `X | Y`
+- `None` can be used for typing directly
+- Type hint doesn't simply make an argument "optional", that's the default value's job

--- a/challenges/basic-optional/question.py
+++ b/challenges/basic-optional/question.py
@@ -1,7 +1,7 @@
 """
 TODO:
 
-foo can accept either an integer argument or no argument.
+foo can accept an integer argument, None or no argument at all.
 """
 
 
@@ -11,6 +11,7 @@ def foo(x):
 
 ## End of your code ##
 foo(10)
+foo(None)
 foo()
 
 foo("10")  # expect-type-error

--- a/challenges/basic-optional/solution.py
+++ b/challenges/basic-optional/solution.py
@@ -4,6 +4,7 @@ def foo(x: int | None = 0):
 
 ## End of your code ##
 foo(10)
+foo(None)
 foo()
 
 foo("10")  # expect-type-error

--- a/challenges/basic-parameter/hints.md
+++ b/challenges/basic-parameter/hints.md
@@ -1,0 +1,1 @@
+The syntax for adding type hints to an argument is: `foo(x: T)`, replace `T` with the real type.

--- a/challenges/basic-return/hints.md
+++ b/challenges/basic-return/hints.md
@@ -1,0 +1,1 @@
+The syntax for adding type hints to a return value is: `foo() -> T`, replace `T` with the real type.

--- a/challenges/basic-tuple/hints.md
+++ b/challenges/basic-tuple/hints.md
@@ -1,0 +1,1 @@
+Check out [Tuple](https://docs.python.org/3/library/typing.html#typing.Tuple).

--- a/challenges/basic-typealias/hints.md
+++ b/challenges/basic-typealias/hints.md
@@ -1,0 +1,1 @@
+Check out [TypeAlias](https://docs.python.org/3/library/typing.html#typing.TypeAlias).

--- a/challenges/basic-union/hints.md
+++ b/challenges/basic-union/hints.md
@@ -1,0 +1,2 @@
+- A union type can be created using the `|` operator, e.g: `X | Y`
+- or using [Union](https://docs.python.org/3/library/typing.html#typing.Union)

--- a/templates/challenge.html
+++ b/templates/challenge.html
@@ -98,7 +98,9 @@
     .hints-container .hints-message * {
       font-size: 13px;
     }
-
+    .hints-container .hints-message ul {
+      margin-bottom: 0;
+    }
     .challenge-main {
       display: flex;
       justify-content: space-between;
@@ -276,7 +278,7 @@
           {% if hints_for_display %}
             <a id="read-hints" role="button" class="secondary outline" href="javascript:void(0);">💡 Read Hints</a>
           {% else %}
-            <div id="hints-missing" href="javascript:void(0);">💡 No Hints Available</div>
+            <div id="hints-missing">💡 No Hints Available</div>
           {% endif %}
           <article class="hints-message">{{hints_for_display | safe}}</article>
         </div>


### PR DESCRIPTION
For people who don't have much experience with type hinting, the basic challenges would be a great place to start, and a hint message can be really useful for them. So I added a hint message for most of the basic challenges.

When processing `basic-optional`, I found that the original code does not require the user to add `| None` or `Optional` hinting, `foo(x: int= 0)` is sufficient. So I modified the validation code to make sure the optional hinting must be used.