### PR TITLE
Support test_code to add pyright-config comment

### DIFF
--- a/challenges/advanced-forward/question.py
+++ b/challenges/advanced-forward/question.py
@@ -14,3 +14,6 @@ from typing import assert_type
 
 inst = MyClass(x=1)
 assert_type(inst.copy(), MyClass)
+
+## End of test code ##
+# pyright: analyzeUnannotatedFunctions=false

--- a/docs/Contribute.md
+++ b/docs/Contribute.md
@@ -42,6 +42,7 @@ Once you come up with an idea, go to the next steps.
    - Describe the challenge, make sure people understand what they need to accomplish (i.e. the `TODO:` part)
    - A comment `## End of your code ##`. This is mandatory, just copy and paste it.
    - Several test cases. Add a comment `# expect-type-error` after the lines where type errors should be thrown.
+   - (Optional) Add a comment `## End of test code ##`.Several [pyright-config](https://github.com/microsoft/pyright/blob/main/docs/configuration.md#type-check-diagnostics-settings) with the format `# pyright: <config_name>=<value>`
 
    `solution.py` contains the right solution, with everything else unchanged.
 

--- a/docs/Contribute.md
+++ b/docs/Contribute.md
@@ -42,7 +42,7 @@ Once you come up with an idea, go to the next steps.
    - Describe the challenge, make sure people understand what they need to accomplish (i.e. the `TODO:` part)
    - A comment `## End of your code ##`. This is mandatory, just copy and paste it.
    - Several test cases. Add a comment `# expect-type-error` after the lines where type errors should be thrown.
-   - (Optional) Add a comment `## End of test code ##`.Several [pyright-config](https://github.com/microsoft/pyright/blob/main/docs/configuration.md#type-check-diagnostics-settings) with the format `# pyright: <config_name>=<value>`
+   - (Optional) Add a comment `## End of test code ##`. Several [pyright-config](https://github.com/microsoft/pyright/blob/main/docs/configuration.md#type-check-diagnostics-settings) with the format `# pyright: <config_name>=<value>`
 
    `solution.py` contains the right solution, with everything else unchanged.
 

--- a/tests/assets/challenges/basic-foo-pyright-config/question.py
+++ b/tests/assets/challenges/basic-foo-pyright-config/question.py
@@ -1,0 +1,14 @@
+"""A simple question, only for running tests.
+"""
+
+
+def foo():
+    pass
+
+
+## End of your code ##
+foo(1)
+foo(1, 2)  # expect-type-error
+
+## End of test code ##
+# pyright: reportGeneralTypeIssues=error

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import pytest
 from flask.testing import FlaskClient
 
 from app import app
+from views.challenge import ChallengeManager
 
 CHALLENGES_DIR = Path(__file__).parent.parent / "challenges"
 ALL_QUESTIONS = list(CHALLENGES_DIR.glob("**/question.py"))
@@ -20,6 +21,11 @@ ALL_SOLUTIONS = list(CHALLENGES_DIR.glob("**/solution*.py"))
 def assets_dir() -> Path:
     """The directory contains test assets."""
     return Path(__file__).parent / "assets"
+
+
+@pytest.fixture()
+def mgr(assets_dir: Path):
+    return ChallengeManager(assets_dir / "challenges")
 
 
 @pytest.fixture()

--- a/tests/test_challenge.py
+++ b/tests/test_challenge.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 
-import pytest
 from views.challenge import ChallengeKey, ChallengeManager
 
 
@@ -11,23 +10,24 @@ class TestLoadChallenges:
     def test_defaults(self):
         assert ChallengeManager().challenge_count > 0
 
-    def test_load_tests_assets(self, assets_dir):
-        mgr = ChallengeManager(assets_dir / "challenges")
+    def test_load_tests_assets(self, mgr: ChallengeManager):
         assert mgr.challenge_count > 0
+
+    def test_partition_test_code(self, mgr: ChallengeManager):
+        pyright_config_test = mgr.get_challenge(
+            ChallengeKey.from_str("basic-foo-pyright-config")
+        ).test_code
+
+        _, pyright_basic_config = mgr._partition_test_code(pyright_config_test)
+        assert pyright_basic_config.endswith("pyright: reportGeneralTypeIssues=error\n")
 
 
 class TestChallengeWithHints:
-    @pytest.fixture()
-    def challenge_mgr(self, assets_dir):
-        return ChallengeManager(assets_dir / "challenges")
-
-    def test_misc(self, challenge_mgr):
-        c_foo = challenge_mgr.get_challenge(ChallengeKey.from_str("basic-foo"))
+    def test_misc(self, mgr: ChallengeManager):
+        c_foo = mgr.get_challenge(ChallengeKey.from_str("basic-foo"))
         assert c_foo.hints is None
 
         # Get the challenge with hints
-        c_foo_hints = challenge_mgr.get_challenge(
-            ChallengeKey.from_str("basic-foo-hints")
-        )
+        c_foo_hints = mgr.get_challenge(ChallengeKey.from_str("basic-foo-hints"))
         assert c_foo_hints.hints
         assert isinstance(c_foo_hints.hints, str)

--- a/tests/test_identical.py
+++ b/tests/test_identical.py
@@ -8,17 +8,19 @@ from views.challenge import Challenge, Level
 
 
 def test_identical(solution_file: Path):
-    level, challenge_name = solution_file.parent.name.split("-", maxsplit=1)
-    with solution_file.open() as f:
-        solution_code = f.read()
-    solution_test = Challenge(
-        name=challenge_name, level=Level(level), code=solution_code
-    ).test_code
+    def get_test_code(path: Path):
+        TEST_SPLITTER = "\n## End of test code ##\n"
+        level, challenge_name = path.parent.name.split("-", maxsplit=1)
 
-    question_file = solution_file.parent / "question.py"
-    with question_file.open() as f:
-        question_code = f.read()
-    question_test = Challenge(
-        name=challenge_name, level=Level(level), code=question_code
-    ).test_code
+        with solution_file.open() as f:
+            challenge_code = f.read()
+        challenge = Challenge(
+            name=challenge_name, level=Level(level), code=challenge_code
+        )
+
+        return challenge.test_code.partition(TEST_SPLITTER)[0]
+
+    solution_test = get_test_code(solution_file)
+    question_test = get_test_code(solution_file.parent / "question.py")
+
     assert solution_test.strip() == question_test.strip()

--- a/tests/test_questions.py
+++ b/tests/test_questions.py
@@ -4,8 +4,6 @@ Make sure all questions fail type check.
 
 from pathlib import Path
 
-import pytest
-
 from views.challenge import ChallengeManager
 
 

--- a/views/views.py
+++ b/views/views.py
@@ -59,7 +59,7 @@ def get_challenge(level: str, name: str):
         "level": challenge.level,
         "challenges_groupby_level": challenge_manager.challenges_groupby_level,
         "code_under_test": challenge.user_code,
-        "test_code": challenge.test_code,
+        "test_code": challenge.test_code.partition("\n## End of test code ##\n")[0],
         "hints_for_display": render_hints(challenge.hints) if challenge.hints else None,
         "python_info": platform.python_version(),
     }


### PR DESCRIPTION
## New feature

support test_code to add pyright-config as below.
```py
## End of test code ##
# pyright: analyzeUnannotatedFunctions=false
```

## Bug fix

disable user to modify pyright-config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Pyright configuration directives in challenge test code
  * Improved test code partitioning to separate configuration from executable test sections
  * Enhanced error reporting with refined line-number mapping for type-checking results

* **Documentation**
  * Updated contribution guidelines with optional test code section formatting instructions

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->