### PR TITLE
Change link in intermediate-empty-tuple

### DIFF
--- a/challenges/intermediate-empty-tuple/hints.md
+++ b/challenges/intermediate-empty-tuple/hints.md
@@ -1,1 +1,1 @@
-Check out [annotating-tuples](https://docs.python.org/zh-cn/3/library/typing.html#annotating-tuples)
+Check out [annotating-tuples](https://docs.python.org/3/library/typing.html#annotating-tuples)


### PR DESCRIPTION
Change link in intermediate-empty-tuple so that it links to the english documentation page