### PR TITLE
Fix: Remove function implementations to force return type to be checked.

### DIFF
--- a/challenges/intermediate-generic/question.py
+++ b/challenges/intermediate-generic/question.py
@@ -6,7 +6,7 @@ The function `add` accepts two arguments and returns a value, they all have the 
 
 
 def add(a, b):
-    return a
+    ...
 
 
 ## End of your code ##

--- a/challenges/intermediate-generic/solution.py
+++ b/challenges/intermediate-generic/solution.py
@@ -11,12 +11,12 @@ The function `add` accepts two arguments and returns a value, they all have the 
 #
 #
 # def add(a: T, b: T) -> T:
-#     return a
+#     ...
 
 
 # For Python >= 3.12
 def add[T](a: T, b: T) -> T:
-    return a
+    ...
 
 
 ## End of your code ##

--- a/challenges/intermediate-generic2/question.py
+++ b/challenges/intermediate-generic2/question.py
@@ -7,7 +7,7 @@ The type can only be str or int (or their subclasses).
 
 
 def add(a, b):
-    return a
+    ...
 
 
 ## End of your code ##

--- a/challenges/intermediate-generic2/solution.py
+++ b/challenges/intermediate-generic2/solution.py
@@ -11,12 +11,12 @@ The type can only be str or int (or their subclasses).
 #
 #
 # def add(a: T, b: T) -> T:
-#     return a
+#     ...
 
 
 # For Python >= 3.12
 def add[T: (str, int)](a: T, b: T) -> T:
-    return a
+    ...
 
 
 ## End of your code ##

--- a/challenges/intermediate-generic3/question.py
+++ b/challenges/intermediate-generic3/question.py
@@ -7,7 +7,7 @@ The type can only be int or subclasses of int.
 
 
 def add(a):
-    return a
+    ...
 
 
 ## End of your code ##

--- a/challenges/intermediate-generic3/solution.py
+++ b/challenges/intermediate-generic3/solution.py
@@ -11,12 +11,12 @@ The type can only be int or subclasses of int.
 #
 #
 # def add(a: T) -> T:
-#     return a
+#     ...
 
 
 # For Python >= 3.12
 def add[T: int](a: T) -> T:
-    return a
+    ...
 
 
 ## End of your code ##


### PR DESCRIPTION
When completing the "generic" challengers the return type is not enforced.
e.g.
```python
def add[T](a: T, b: T) -> T:
    return a


def add[T](a: T, b: T):
    return a
```
both the above functions pass the first "generic" challenge
 
By removing the function implementation (`return a`) and replacing it with `...`, the 2nd function in the above code snippet becomes an invalid.