### PR TITLE
fix: pyright playground code lacks of newlines

### DIFF
--- a/templates/components/challenge_area.html
+++ b/templates/components/challenge_area.html
@@ -110,7 +110,7 @@
 
     let playgroundLink = document.getElementById("playground-link");
     playgroundLink.addEventListener('click', function (event) {
-      const code = myCodeMirror.getValue() + testCodeMirror.getValue();
+      const code = myCodeMirror.getValue() + "\n\n" + testCodeMirror.getValue();
       this.href = "https://pyright-play.net/?code=" + LZString.compressToEncodedURIComponent(code);
     });
 


### PR DESCRIPTION
Add newlines between the "user input code" and "test code".

A bad case: https://pyright-play.net/?code=EQhQBUHkBFILlKAwgJwKYEMAuaAEHcA7NAd1ywE8AHPAYwwBsG0ATXANTVqwHsUAaXCQAWAS1rDcogM75cDGVlw8AZrhUMe2AHSgQwRJ259cAXnmKA2hq1YAuizRqVPHgAoAbnA5deKAJQIuMG42mGIoC7ulgCM2jGCAEx2-pGubjH%2BwQDEuGgAHjTcALSUNMVoKCh8adHAMcApOXmFvqXUaBVVNUA